### PR TITLE
added portainer

### DIFF
--- a/portainer-agent-stack.yml
+++ b/portainer-agent-stack.yml
@@ -1,0 +1,39 @@
+version: '3.2'
+
+services:
+  agent:
+    image: portainer/agent:2.19.5
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/lib/docker/volumes:/var/lib/docker/volumes
+    networks:
+      - agent_network
+    deploy:
+      mode: global
+      placement:
+        constraints: [node.platform.os == linux]
+
+  portainer:
+    image: portainer/portainer-ce:2.19.5
+    command: -H tcp://tasks.agent:9001 --tlsskipverify
+    ports:
+      - "9443:9443"
+      - "9000:9000"
+      - "8000:8000"
+    volumes:
+      - portainer_data:/data
+    networks:
+      - agent_network
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints: [node.role == manager]
+
+networks:
+  agent_network:
+    driver: overlay
+    attachable: true
+
+volumes:
+  portainer_data:

--- a/services/jobs/cassandra-config/cassandra.yaml
+++ b/services/jobs/cassandra-config/cassandra.yaml
@@ -463,7 +463,7 @@ seed_provider:
     parameters:
       # seeds is actually a comma-delimited list of addresses.
       # Ex: "<ip1>,<ip2>,<ip3>"
-      - seeds: "172.18.0.2"
+      - seeds: "10.0.3.16"
 
 # For workloads with more data than can fit in memory, Cassandra's
 # bottleneck will be reads that need to fetch data from
@@ -663,7 +663,7 @@ ssl_storage_port: 7001
 #
 # Setting listen_address to 0.0.0.0 is always wrong.
 #
-listen_address: 172.18.0.2
+listen_address: 10.0.3.16
 
 # Set listen_address OR listen_interface, not both. Interfaces must correspond
 # to a single address, IP aliasing is not supported.
@@ -677,7 +677,7 @@ listen_address: 172.18.0.2
 
 # Address to broadcast to other Cassandra nodes
 # Leaving this blank will set it to the same value as listen_address
-broadcast_address: 172.18.0.2
+broadcast_address: 10.0.3.16
 
 # When using multiple physical network interfaces, set this
 # to true to listen on broadcast_address in addition to
@@ -763,7 +763,7 @@ rpc_address: 0.0.0.0
 # be set to 0.0.0.0. If left blank, this will be set to the value of
 # rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
 # be set.
-broadcast_rpc_address: 172.18.0.2
+broadcast_rpc_address: 10.0.3.16
 
 # enable or disable keepalive on rpc/native connections
 rpc_keepalive: true


### PR DESCRIPTION
Added docker portainer

You can run the portainer from the root of the project as : 
      - docker stack deploy -c portainer-agent-stack.yml
      - access it from localhost on ports 9443 or 9000
      - login if created an account for it before if not create your account and it will be saved on a mounted volume on your machine and you can use it later.
